### PR TITLE
Fix publishing of multiple markdown files at once

### DIFF
--- a/src/main/java/de/adesso/service/FileTransfer.java
+++ b/src/main/java/de/adesso/service/FileTransfer.java
@@ -40,12 +40,6 @@ public class FileTransfer {
                 }
                 Files.copy(source.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING,
                         StandardCopyOption.COPY_ATTRIBUTES);
-				/*
-				 * Deletes all XML-Files in the
-				 * _site/blog-posts/... folder
-				 */
-                this.deleteXmlFromSiteFolder();
-
             }
         } catch (IOException e) {
             LOGGER.error("An error occured while copying generated XML files to destinantion");

--- a/src/main/java/de/adesso/service/MarkdownTransformer.java
+++ b/src/main/java/de/adesso/service/MarkdownTransformer.java
@@ -104,6 +104,7 @@ public class MarkdownTransformer {
                 }
             }
         });
+        fileTransfer.deleteXmlFromSiteFolder();
     }
 
     /**
@@ -132,6 +133,7 @@ public class MarkdownTransformer {
                             + FilenameUtils.getBaseName(f.getAbsolutePath() + ".xml"));
             fileTransfer.copyFile(f, dest);
         });
+        fileTransfer.deleteXmlFromSiteFolder();
     }
 
     /**

--- a/src/main/resources/application-sample.properties
+++ b/src/main/resources/application-sample.properties
@@ -14,7 +14,7 @@ spring.profiles.active=dev
 repository.remote.url=https://github.com/USER_NAME/REPOSITORY_NAME
 
 # path on the repository to which the generated JSON File is stored
-repository.local.JSON.path = ${repository.local.path}assets/commit/commitInformation.json
+repository.local.JSON.path = ${repository.local.path}assets/commit/commitinformation.json
 
 # local path where the remote repository is cloned to. This local copy should only be used by jekyll2cms
 repository.local.path=repo/


### PR DESCRIPTION
There was an error when multiple markdown files were modified at once, so the xml files did not get moved to the right position correctly, because they all got deleted after the first file was moved which lead to errors.