### PR TITLE
update commit message generation, fix gitattributes handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 	compile('org.springframework.boot:spring-boot-starter-web')
 	compile('org.springframework.boot:spring-boot-starter-mail')
-	compile('org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r')
+	compile('org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r')
 	compile('org.apache.commons:commons-exec:1.3')
 	compile('commons-cli:commons-cli:1.4')
 	compile('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9')

--- a/src/main/java/de/adesso/service/GitRepoPusher.java
+++ b/src/main/java/de/adesso/service/GitRepoPusher.java
@@ -10,6 +10,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class GitRepoPusher {
 
@@ -48,6 +52,7 @@ public class GitRepoPusher {
                         .setMessage(getCommitMessage())
                         .setAuthor(configService.getGIT_AUTHOR_NAME(), configService.getGIT_AUTHOR_MAIL())
                         .call();
+
                 CredentialsProvider cp = new UsernamePasswordCredentialsProvider(configService.getGIT_AUTHOR_NAME(), configService.getGIT_AUTHOR_PASSWORD());
                 localGit.push().setForce(false).setCredentialsProvider(cp).call();
                 LOGGER.info("XML files pushed successfully.");
@@ -71,9 +76,9 @@ public class GitRepoPusher {
      */
     private String getCommitMessage() throws GitAPIException {
         Status status = LocalRepoCreater.getLocalGit().status().call();
-        StringBuilder commitMessageBuilder = new StringBuilder();
-        status.getAdded().forEach(file -> commitMessageBuilder.append("ADD ").append(file).append("\n"));
-        status.getRemoved().forEach(file -> commitMessageBuilder.append("DELETE ").append(file).append("\n"));
-        return commitMessageBuilder.toString();
+        List<String> messages = new ArrayList<>();
+        messages.addAll(status.getAdded().stream().map(file -> "ADD " + file).collect(Collectors.toList()));
+        messages.addAll(status.getRemoved().stream().map(file -> "DELETE " + file).collect(Collectors.toList()));
+        return String.join("\n", messages);
     }
 }


### PR DESCRIPTION
Due to gitattributes handling end of line problematic (crlf -> lf) jekyll2cms couldn't handle the repository. Increasing the jGit version, fixes this problem according to [this bug report](https://bugs.eclipse.org/bugs/show_bug.cgi?id=561341)